### PR TITLE
Deprecated Mongo class: Mongo ==> MongoClient

### DIFF
--- a/db.php
+++ b/db.php
@@ -25,7 +25,7 @@ class DB {
 	            echo ("The MongoDB PECL extension has not been installed or enabled");
 	            return false;
 	        }
-			$connection=  new \Mongo($config['connection_string'],array('username'=>$config['username'],'password'=>$config['password']));
+			$connection=  new \MongoClient($config['connection_string'],array('username'=>$config['username'],'password'=>$config['password']));
 	    	return $this->db = $connection->selectDB($config['dbname']);
 		}catch(Exception $e) {
 			return false;


### PR DESCRIPTION
Fixes error: "Deprecated: Blog\DB\DB::connect(): The Mongo class is deprecated, please use the MongoClient class in /Applications/MAMP/htdocs/voterdb/php-mongodb-master/db.php on line 28"
